### PR TITLE
Cope with lib64 directory

### DIFF
--- a/actions/test_stdlib_import.py
+++ b/actions/test_stdlib_import.py
@@ -22,7 +22,7 @@ class TestStdlibImportAction(Action):
         cluster = Cluster()  # NOQA
 
         import concurrent
-        if 'lib/python3' not in concurrent.__file__:
+        if 'lib/python3' not in concurrent.__file__ and 'lib64/python3' not in concurrent.__file__:
             msg = 'concurrent module was not imported from Python 3 stdlib'
             return False, msg
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description : StackStorm pack for testing various Python 3 functionality
 keywords:
   - python3
   - test
-version: 0.1.0
+version: 0.1.1
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
Update so that handles case where concurrent is in file lib64/concurrent rather than lib/concurrent